### PR TITLE
Adapt training to multi-dataset mode (flexai-main)

### DIFF
--- a/config/finetune_shakespeare.py
+++ b/config/finetune_shakespeare.py
@@ -8,6 +8,7 @@ wandb_log = False # feel free to turn on
 wandb_project = 'shakespeare'
 wandb_run_name = 'ft-' + str(time.time())
 
+dataset_dir = 'nanogpt-dataset'
 dataset = 'shakespeare'
 init_from = 'gpt2-xl' # this is the largest GPT-2 model
 

--- a/config/train_shakespeare_char.py
+++ b/config/train_shakespeare_char.py
@@ -14,6 +14,7 @@ wandb_log = False # override via command line if you like
 wandb_project = 'shakespeare-char'
 wandb_run_name = 'mini-gpt'
 
+dataset_dir = 'nanogpt-dataset'
 dataset = 'shakespeare_char'
 gradient_accumulation_steps = 1
 batch_size = 64

--- a/train.py
+++ b/train.py
@@ -45,6 +45,7 @@ wandb_log = False # disabled by default
 wandb_project = 'owt'
 wandb_run_name = 'gpt2' # 'run' + str(time.time())
 # data
+dataset_dir = ''
 dataset = 'openwebtext'
 gradient_accumulation_steps = 5 * 8 # used to simulate larger batch sizes
 batch_size = 12 # if gradient_accumulation_steps > 1, this is the micro-batch size
@@ -113,7 +114,7 @@ ptdtype = {'float32': torch.float32, 'bfloat16': torch.bfloat16, 'float16': torc
 ctx = nullcontext() if device_type == 'cpu' else torch.amp.autocast(device_type=device_type, dtype=ptdtype)
 
 # poor man's data loader
-data_dir = os.path.join('/input', dataset)
+data_dir = os.path.join('/input', dataset_dir, dataset)
 if not os.path.exists(data_dir):
     data_dir = os.path.join('data', dataset)
 def get_batch(split):


### PR DESCRIPTION
This change adapts the `flexai-main` revision (used in the basic E2E test) for the multi-dataset training mode.

Refs: PAAS-1633